### PR TITLE
Fix size of array elements and add block for entire array

### DIFF
--- a/src/peakrdl_rawheader/__peakrdl__.py
+++ b/src/peakrdl_rawheader/__peakrdl__.py
@@ -67,8 +67,6 @@ class HeaderGeneratorDescriptor(ExporterSubcommandPlugin):
         blocks = get_regs(top_node)
         enums = get_enums(top_node)
 
-        # print(enums)
-
         # Render and write
         rendered = tmpl.render(top_name=top_name, blocks=blocks, license_str=license_str, enums=enums)
         with open(output_path, "w") as f:

--- a/src/peakrdl_rawheader/rawheader_fns.py
+++ b/src/peakrdl_rawheader/rawheader_fns.py
@@ -36,7 +36,8 @@ def get_regs(node: AddrmapNode, prefix: str = ""):
                 block.append([])
                 block.append([
                     {"name": start_basename + "_BASE_ADDR", "num": subnode.absolute_address},
-                    {"name": start_basename + "_SIZE     ", "num": subnode.total_size}
+                    {"name": start_basename + "_SIZE     ", "num": subnode.total_size},
+                    {"name": start_basename + "_STRIDE   ", "num": subnode.array_stride},
                 ])
 
         # Handle different subnode types

--- a/src/peakrdl_rawheader/rawheader_fns.py
+++ b/src/peakrdl_rawheader/rawheader_fns.py
@@ -7,38 +7,53 @@
 
 from systemrdl.node import AddrmapNode, RegNode, MemNode, RegfileNode, FieldNode
 
+
 def get_regs(node: AddrmapNode, prefix: str = ""):
     """Recursively get all registers in the addrmap tree."""
     start_basename = prefix + node.inst_name.upper()
     nodes = []
     block = []
     subblock = []
+
+    # Create a list of nodes, from the nodes in an array node or from a single scalar node
     if node.is_array:
         nodes = node.unrolled()
     else:
         nodes = [node]
 
-    for subnode in nodes:
+    # Iterate over subnodes
+    for i, subnode in enumerate(nodes):
+
+        # If subnode is part of an array, add the index within the array to its basename.
+        # Also, add a block for the base address and total size of the array.
         basename = start_basename
         if node.is_array:
             for idx in subnode.current_idx:
                 basename += "_" + str(idx)
+            # absolute_address cannot be called on array nodes, so we get the information
+            # from subnode 0
+            if i == 0:
+                block.append([])
+                block.append([
+                    {"name": start_basename + "_BASE_ADDR", "num": subnode.absolute_address},
+                    {"name": start_basename + "_SIZE     ", "num": subnode.total_size}
+                ])
+
+        # Handle different subnode types
         if isinstance(subnode, RegNode):
             subblock.extend([{"name": basename + "_REG_ADDR  ", "num": subnode.absolute_address},
                              {"name": basename + "_REG_OFFSET", "num": subnode.address_offset}])
             block = [subblock]
         elif isinstance(subnode, AddrmapNode) or isinstance(node, RegfileNode):
             block.append([])
-            block.append([{ "name": basename + "_BASE_ADDR", "num": subnode.absolute_address },
-                          { "name": basename + "_SIZE     ", "num": subnode.total_size }])
-
+            block.append([{"name": basename + "_BASE_ADDR", "num": subnode.absolute_address},
+                          {"name": basename + "_SIZE     ", "num": subnode.total_size}])
             for child in subnode.children():
                 block.extend(get_regs(child, basename + "_"))
-
         elif isinstance(subnode, MemNode):
             block.append([])
             block.append([{"name": basename + "_BASE_ADDR", "num": subnode.absolute_address},
-                          {"name": basename + "_SIZE     ", "num": subnode.total_size}])
+                          {"name": basename + "_SIZE     ", "num": subnode.size}])
         else:
             print(f"Unknown node type: {type(node)}")
 

--- a/src/peakrdl_rawheader/rawheader_fns.py
+++ b/src/peakrdl_rawheader/rawheader_fns.py
@@ -47,7 +47,7 @@ def get_regs(node: AddrmapNode, prefix: str = ""):
         elif isinstance(subnode, AddrmapNode) or isinstance(node, RegfileNode):
             block.append([])
             block.append([{"name": basename + "_BASE_ADDR", "num": subnode.absolute_address},
-                          {"name": basename + "_SIZE     ", "num": subnode.total_size}])
+                          {"name": basename + "_SIZE     ", "num": subnode.size}])
             for child in subnode.children():
                 block.extend(get_regs(child, basename + "_"))
         elif isinstance(subnode, MemNode):


### PR DESCRIPTION
Consider the following RDL line from Picobello:
```
  external mem { mementries = 0x40000; memwidth = 32; } l2_spm[8] @0x70000000 += 0x100000;
```

This results in the following snippet in the raw C header:
```
#define PICOBELLO_ADDRMAP_L2_SPM_0_BASE_ADDR 0x70000000
#define PICOBELLO_ADDRMAP_L2_SPM_0_SIZE      0x00800000


#define PICOBELLO_ADDRMAP_L2_SPM_1_BASE_ADDR 0x70100000
#define PICOBELLO_ADDRMAP_L2_SPM_1_SIZE      0x00800000


#define PICOBELLO_ADDRMAP_L2_SPM_2_BASE_ADDR 0x70200000
#define PICOBELLO_ADDRMAP_L2_SPM_2_SIZE      0x00800000


#define PICOBELLO_ADDRMAP_L2_SPM_3_BASE_ADDR 0x70300000
#define PICOBELLO_ADDRMAP_L2_SPM_3_SIZE      0x00800000


#define PICOBELLO_ADDRMAP_L2_SPM_4_BASE_ADDR 0x70400000
#define PICOBELLO_ADDRMAP_L2_SPM_4_SIZE      0x00800000


#define PICOBELLO_ADDRMAP_L2_SPM_5_BASE_ADDR 0x70500000
#define PICOBELLO_ADDRMAP_L2_SPM_5_SIZE      0x00800000


#define PICOBELLO_ADDRMAP_L2_SPM_6_BASE_ADDR 0x70600000
#define PICOBELLO_ADDRMAP_L2_SPM_6_SIZE      0x00800000


#define PICOBELLO_ADDRMAP_L2_SPM_7_BASE_ADDR 0x70700000
#define PICOBELLO_ADDRMAP_L2_SPM_7_SIZE      0x00800000
```

This incorrectly defines the size of e.g. the L2_SPM_0 block, to that of the entire array. This includes also the stride between array elements, which can be different from the size of its elements.

This PR fixes this behaviour, and adds a block for the entire array, so that the total size is also available. So the following snippet would instead be generated:
```
#define PICOBELLO_ADDRMAP_L2_SPM_BASE_ADDR 0x70000000
#define PICOBELLO_ADDRMAP_L2_SPM_SIZE      0x00800000


#define PICOBELLO_ADDRMAP_L2_SPM_0_BASE_ADDR 0x70000000
#define PICOBELLO_ADDRMAP_L2_SPM_0_SIZE      0x00100000


#define PICOBELLO_ADDRMAP_L2_SPM_1_BASE_ADDR 0x70100000
#define PICOBELLO_ADDRMAP_L2_SPM_1_SIZE      0x00100000


#define PICOBELLO_ADDRMAP_L2_SPM_2_BASE_ADDR 0x70200000
#define PICOBELLO_ADDRMAP_L2_SPM_2_SIZE      0x00100000


#define PICOBELLO_ADDRMAP_L2_SPM_3_BASE_ADDR 0x70300000
#define PICOBELLO_ADDRMAP_L2_SPM_3_SIZE      0x00100000


#define PICOBELLO_ADDRMAP_L2_SPM_4_BASE_ADDR 0x70400000
#define PICOBELLO_ADDRMAP_L2_SPM_4_SIZE      0x00100000


#define PICOBELLO_ADDRMAP_L2_SPM_5_BASE_ADDR 0x70500000
#define PICOBELLO_ADDRMAP_L2_SPM_5_SIZE      0x00100000


#define PICOBELLO_ADDRMAP_L2_SPM_6_BASE_ADDR 0x70600000
#define PICOBELLO_ADDRMAP_L2_SPM_6_SIZE      0x00100000


#define PICOBELLO_ADDRMAP_L2_SPM_7_BASE_ADDR 0x70700000
#define PICOBELLO_ADDRMAP_L2_SPM_7_SIZE      0x00100000
```